### PR TITLE
Add operator overloading for ++ and --

### DIFF
--- a/lib/Class/Type/Enum.pm
+++ b/lib/Class/Type/Enum.pm
@@ -86,6 +86,8 @@ use overload (
   '""'     => 'stringify',
   'cmp'    => 'cmp',
   '0+'     => 'numify',
+  '++'     => 'incr',
+  '--'     => 'decr',
   fallback => 1,
 );
 
@@ -364,6 +366,28 @@ sub cmp {
     unless defined $ord;
 
   return $$self <=> $ord;
+}
+
+=method $o->incr
+
+The increment method used for the increment operator (C<++>, prefix or
+suffix). Mutates the object, incrementing its value by one.
+
+=cut
+
+sub incr {
+  ++${$_[0]};
+}
+
+=method $o->decr
+
+The decrement method used for the decrement operator (C<-->, prefix or
+suffix). Mutates the object, decrementing its value by one.
+
+=cut
+
+sub decr {
+  --${$_[0]};
 }
 
 =method $o->any(@cases)


### PR DESCRIPTION
Sometimes, it's useful to be able to easily modify an enum variable:

    package My::State;
    use Class::Type::Enum values => qw/waiting queued running done/;

    my $state = My::State->new("waiting");

    ... # wait for things to change

    $state++; # state is now "queued"

Add operators to allow that type of behavior.